### PR TITLE
Standardize on name of stepper namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ somethingCrazy xs =
     Transducers.transduce
         ( Transducers.concat TList.stepper
             |> compose (Transducers.mapInput (\x -> List.range 1 x))
-            |> compose (Transducers.concat TCList.stepper)
+            |> compose (Transducers.concat TList.stepper)
             |> compose (Transducers.filter (\x -> x % 2 == 0))
             |> compose (Transducers.take 3)
             |> compose (Transducers.fold (::) [])


### PR DESCRIPTION
I believe this wants to be `TList`, not `TCList`